### PR TITLE
Add flag to use touranchor--is-active css class or not

### DIFF
--- a/projects/ngx-ui-tour-console/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-ui-tour-console/src/lib/tour-anchor.directive.ts
@@ -36,7 +36,7 @@ export class TourAnchorConsoleDirective implements OnInit, OnDestroy, TourAnchor
   public showTourStep(step: IStepOption): void {
     const htmlElement: HTMLElement = this.element.nativeElement;
 
-    this.isActive = true;
+    this.isActive =  step.useIsActiveCSSClass ? true : false;
     if (!step.disableScrollToAnchor) {
       ScrollingUtil.ensureVisible(htmlElement);
     }

--- a/projects/ngx-ui-tour-core/src/lib/tour.service.ts
+++ b/projects/ngx-ui-tour-core/src/lib/tour.service.ts
@@ -23,6 +23,7 @@ export interface IStepOption {
     isAsync?: boolean;
     isOptional?: boolean;
     delayAfterNavigation?: number;
+    useIsActiveCSSClass: boolean;
 }
 
 export enum TourState {

--- a/projects/ngx-ui-tour-core/src/lib/tour.service.ts
+++ b/projects/ngx-ui-tour-core/src/lib/tour.service.ts
@@ -23,7 +23,7 @@ export interface IStepOption {
     isAsync?: boolean;
     isOptional?: boolean;
     delayAfterNavigation?: number;
-    useIsActiveCSSClass: boolean;
+    useIsActiveCSSClass?: boolean;
 }
 
 export enum TourState {

--- a/projects/ngx-ui-tour-md-menu/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-ui-tour-md-menu/src/lib/tour-anchor.directive.ts
@@ -61,7 +61,7 @@ export class TourAnchorMatMenuDirective
   public showTourStep(step: IMdStepOption): void {
     const htmlElement: HTMLElement = this.element.nativeElement;
 
-    this.isActive = true;
+    this.isActive =  step.useIsActiveCSSClass ? true : false; 
     this.tourStepTemplate.templateComponent.step = step;
     // Ignore step.placement
     if (!step.disableScrollToAnchor) {

--- a/projects/ngx-ui-tour-ng-bootstrap/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-ui-tour-ng-bootstrap/src/lib/tour-anchor.directive.ts
@@ -44,7 +44,7 @@ export class TourAnchorNgBootstrapDirective implements OnInit, OnDestroy, TourAn
   public showTourStep(step: INgbStepOption): void {
     const htmlElement: HTMLElement = this.element.nativeElement;
 
-    this.isActive = true;
+    this.isActive =  step.useIsActiveCSSClass ? true : false;
     this.popoverDirective.ngbPopover = this.tourStepTemplate.template;
     this.popoverDirective.popoverTitle = step.title;
     this.popoverDirective.container =  'body';

--- a/projects/ngx-ui-tour-ngx-bootstrap/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-ui-tour-ngx-bootstrap/src/lib/tour-anchor.directive.ts
@@ -42,7 +42,7 @@ export class TourAnchorNgxBootstrapDirective
   public showTourStep(step: IStepOption): void {
     const htmlElement: HTMLElement = this.element.nativeElement;
 
-    this.isActive = true;
+    this.isActive =  step.useIsActiveCSSClass ? true : false;
     this.popoverDirective.popover = this.tourStepTemplate.template;
     this.popoverDirective.popoverContext = { step };
     this.popoverDirective.popoverTitle = step.title;

--- a/projects/ngx-ui-tour-tui-dropdown/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-ui-tour-tui-dropdown/src/lib/tour-anchor.directive.ts
@@ -46,7 +46,7 @@ export class TourAnchorTuiDropdownDirective implements OnInit, OnDestroy, TourAn
             templateComponent = this.tourStepTemplateService.templateComponent;
 
         templateComponent.step = step;
-        this.isActive = true;
+        this.isActive =  step.useIsActiveCSSClass ? true : false;
 
         if (!step.disableScrollToAnchor) {
             ScrollingUtil.ensureVisible(htmlElement);

--- a/projects/ngx-ui-tour-tui-hint/src/lib/tour-anchor.directive.ts
+++ b/projects/ngx-ui-tour-tui-hint/src/lib/tour-anchor.directive.ts
@@ -40,7 +40,7 @@ export class TourAnchorTuiHintDirective implements OnInit, OnDestroy, TourAnchor
             templateComponent = this.tourStepTemplateService.templateComponent;
 
         templateComponent.step = step;
-        this.isActive = true;
+        this.isActive =  step.useIsActiveCSSClass ? true : false;
 
         if (!step.disableScrollToAnchor) {
             ScrollingUtil.ensureVisible(htmlElement);


### PR DESCRIPTION
Hi I created this PR so that tour steps can be further configured by using the flag: `useIsActiveCSSClass`.

The idea is that the developer can decide on every step if the CSS class `touranchor--is-active` should be added to the current tour step or not. I think this is a nice addition if developers want to add a custom CSS to one step and just want to use the native backdrop highlighting on another step without using the custom CSS associated with the CSS class `touranchor--is-active`.