### PR TITLE
Add generic type to tour services to customize IStepOption

### DIFF
--- a/projects/ngx-ui-tour-md-menu/src/lib/ngx-md-menu-tour.service.ts
+++ b/projects/ngx-ui-tour-md-menu/src/lib/ngx-md-menu-tour.service.ts
@@ -3,4 +3,4 @@ import {TourService} from 'ngx-ui-tour-core';
 import {IMdStepOption} from './step-option.interface';
 
 @Injectable()
-export class NgxmTourService extends TourService<IMdStepOption> {}
+export class NgxmTourService<T = IMdStepOption> extends TourService<T> {}

--- a/projects/ngx-ui-tour-ng-bootstrap/src/lib/ng-bootstrap-tour.service.ts
+++ b/projects/ngx-ui-tour-ng-bootstrap/src/lib/ng-bootstrap-tour.service.ts
@@ -5,5 +5,5 @@ import { INgbStepOption } from './step-option.interface';
 
 @Injectable({
     providedIn: 'root',
-  })
-export class NgbTourService extends TourService<INgbStepOption> {}
+})
+export class NgbTourService<T = INgbStepOption> extends TourService<T> {}

--- a/projects/ngx-ui-tour-ngx-bootstrap/src/lib/ngx-bootstrap-tour.service.ts
+++ b/projects/ngx-ui-tour-ngx-bootstrap/src/lib/ngx-bootstrap-tour.service.ts
@@ -4,4 +4,4 @@ import { TourService } from 'ngx-ui-tour-core';
 import { INgxbStepOption } from './step-option.interface';
 
 @Injectable()
-export class NgxbTourService extends TourService<INgxbStepOption> {}
+export class NgxbTourService<T = INgxbStepOption> extends TourService<T> {}

--- a/projects/ngx-ui-tour-tui-dropdown/src/lib/tour-tui-dropdown.service.ts
+++ b/projects/ngx-ui-tour-tui-dropdown/src/lib/tour-tui-dropdown.service.ts
@@ -3,4 +3,4 @@ import {TourService} from 'ngx-ui-tour-core';
 import {ITuiDdStepOption} from './step-option.interface';
 
 @Injectable()
-export class TourTuiDropdownService extends TourService<ITuiDdStepOption> {}
+export class TourTuiDropdownService<T = ITuiDdStepOption> extends TourService<T> {}

--- a/projects/ngx-ui-tour-tui-hint/src/lib/tour-tui-hint.service.ts
+++ b/projects/ngx-ui-tour-tui-hint/src/lib/tour-tui-hint.service.ts
@@ -3,4 +3,4 @@ import {TourService} from 'ngx-ui-tour-core';
 import {ITuiHintStepOption} from './step-option.interface';
 
 @Injectable()
-export class TourTuiHintService extends TourService<ITuiHintStepOption> {}
+export class TourTuiHintService<T = ITuiHintStepOption> extends TourService<T> {}


### PR DESCRIPTION
In a project i want to extend the `IStepOption` in the tour service and noticed that it is currently possible in `core` but not in the framework specific libs