### PR TITLE
Add `<tour-proxy-anchor>` component

### DIFF
--- a/projects/ngx-ui-tour-core/src/lib/tour-anchor-overlay.directive.ts
+++ b/projects/ngx-ui-tour-core/src/lib/tour-anchor-overlay.directive.ts
@@ -1,0 +1,33 @@
+import { AfterViewInit, ChangeDetectorRef, Directive, ElementRef, HostBinding, Input } from "@angular/core";
+
+@Directive({
+    standalone: true,
+    selector: '[tourAnchorOverlay]'
+})
+export class TourAnchorOverlayDirective implements AfterViewInit {
+    /** CSS selector to Element which should be overlayed by the tourAnchor */
+    @Input() public tourAnchorOverlay: string;
+    /** Padding around tourAnchor (Pixels) */
+    @Input() public tourAnchorOverlayPadding: number = 0;
+
+    @HostBinding('style.top.px') get top() { return this.boundingRect?.top }
+    @HostBinding('style.left.px') get left() { return this.boundingRect?.left }
+    @HostBinding('style.width.px') get width() { return this.boundingRect?.width }
+    @HostBinding('style.height.px') get height() { return this.boundingRect?.height }
+    @HostBinding('style.padding.px') get padding() { return this.tourAnchorOverlayPadding }
+    @HostBinding('style.margin.px') get margin() { return -this.tourAnchorOverlayPadding }
+
+    public boundingRect?: DOMRect;
+
+    constructor(private cdr: ChangeDetectorRef, el: ElementRef) {
+        el.nativeElement.style.position = 'absolute';
+    }
+
+    ngAfterViewInit(): void {
+        if (this.tourAnchorOverlay) {
+            let element = document.querySelector(this.tourAnchorOverlay) as HTMLElement;
+            this.boundingRect = element?.getBoundingClientRect();
+            this.cdr.detectChanges();
+        }
+    }
+}

--- a/projects/ngx-ui-tour-core/src/public_api.ts
+++ b/projects/ngx-ui-tour-core/src/public_api.ts
@@ -1,5 +1,6 @@
 export {IStepOption, StepDimensions, TourState, TourService, Direction, StepChangeParams} from './lib/tour.service';
 export {TourAnchorDirective} from './lib/tour-anchor.directive';
+export {TourAnchorOverlayDirective} from './lib/tour-anchor-overlay.directive';
 export {TourHotkeyListenerComponent} from './lib/tour-hotkey-listener.component';
 export {isInViewport, ElementSides} from './lib/is-in-viewport';
 export {isCovered} from './lib/is-covered';


### PR DESCRIPTION
In discussion #159 I had the following problem:

I'm using an external component (in this case a calendar component) that contains a button group to switch views. I'm not able to set the `tourAnchor`-Directive on this button group (as the code is not in my domain).

My first solution was to create a `div` and position it absolutely over this button group and use the `tourAnchor`-Directive on this new `div`. If the layout changed somehow and these buttons were not in the same place anymore or changed in dimension, the absolutely positioned `div` was wrong (especially visible, if backdrop is enabled).

So instead of positioning this "artificial" tourAnchor-DIV I've created a directive which receives a CSS selector. This directive finds the element I want to overlay, gets it's bounding rect and sets the `div`'s position and dimensions accordingly.

In this [branch](https://github.com/phrei/ngx-ui-tour/tree/task-Demo-For-TourAnchorOverlay) you can see a demo of the directive. As a test I try to highlight the label of the button instead of the whole button (to showcase an element, that is not in my domain but in angular material's).

Additionally theres an Input for padding (which uses the technique from your docs to set padding and remove margin).