### PR TITLE
md-menu: add full RTL support

### DIFF
--- a/libs/ngx-ui-tour-md-menu/src/lib/tour-step-template/tour-default-step-template/tour-default-step-template.component.html
+++ b/libs/ngx-ui-tour-md-menu/src/lib/tour-step-template/tour-default-step-template/tour-default-step-template.component.html
@@ -4,7 +4,8 @@
     (click)="$event.stopPropagation()"
     [style.width]="step.stepDimensions?.width"
     [style.min-width]="step.stepDimensions?.minWidth"
-    [style.max-width]="step.stepDimensions?.maxWidth">
+    [style.max-width]="step.stepDimensions?.maxWidth"
+>
     <mat-card-header>
         <div class="header-group">
             <mat-card-title>
@@ -13,7 +14,8 @@
             <button
                 mat-icon-button
                 (click)="tourService.end()"
-                class="close">
+                class="close"
+            >
                 <mat-icon>close</mat-icon>
             </button>
         </div>
@@ -21,40 +23,41 @@
 
     <mat-card-content
         class="mat-body"
-        [innerHTML]="step.content"></mat-card-content>
+        [innerHTML]="step.content"
+    ></mat-card-content>
 
-    <mat-card-actions [class.no-progress]="!step.showProgress">
+    <mat-card-actions
+        [class.no-progress]="!step.showProgress"
+    >
         <button
             mat-button
             class="prev"
             [disabled]="!tourService.hasPrev(step)"
-            (click)="tourService.prev()">
+            (click)="tourService.prev()"
+        >
             <mat-icon class="icon">chevron_left</mat-icon>
             {{ step.prevBtnTitle }}
         </button>
         @if (step.showProgress) {
-        <div class="progress">
-            {{ tourService.steps.indexOf(step) + 1 }} /
-            {{ tourService.steps.length }}
-        </div>
-        } @if (tourService.hasNext(step) && !step.nextOnAnchorClick) {
-        <button
-            class="next"
-            (click)="tourService.next()"
-            mat-button>
-            {{ step.nextBtnTitle }}
-            <mat-icon
-                class="icon"
-                iconPositionEnd
-                >chevron_right</mat-icon
+            <div class="progress">{{ tourService.steps.indexOf(step) + 1 }} / {{ tourService.steps.length }}</div>
+        }
+        @if (tourService.hasNext(step) && !step.nextOnAnchorClick) {
+            <button
+                class="next"
+                (click)="tourService.next()"
+                mat-button
             >
-        </button>
-        } @if (!tourService.hasNext(step)) {
-        <button
-            mat-button
-            (click)="tourService.end()">
-            {{ step.endBtnTitle }}
-        </button>
+                {{ step.nextBtnTitle }}
+                <mat-icon class="icon" iconPositionEnd>chevron_right</mat-icon>
+            </button>
+        }
+        @if (!tourService.hasNext(step)) {
+            <button
+                mat-button
+                (click)="tourService.end()"
+            >
+                {{ step.endBtnTitle }}
+            </button>
         }
     </mat-card-actions>
 </mat-card>

--- a/libs/ngx-ui-tour-md-menu/src/lib/tour-step-template/tour-default-step-template/tour-default-step-template.component.scss
+++ b/libs/ngx-ui-tour-md-menu/src/lib/tour-step-template/tour-default-step-template/tour-default-step-template.component.scss
@@ -19,7 +19,7 @@ mat-card-actions {
     .progress {
         font-size: 12px;
         font-weight: 600;
-        color: rgba(0, 0, 0, 0.38);
+        color: rgba(0, 0, 0, .38);
         white-space: nowrap;
     }
 
@@ -27,7 +27,7 @@ mat-card-actions {
         grid-template-columns: 1fr 1fr;
     }
 
-    > * {
+    >* {
         max-width: fit-content;
 
         &:last-child {
@@ -49,6 +49,7 @@ mat-card-actions {
         transform: scaleX(-1);
     }
 }
+
 
 mat-card-header {
     .header-group {


### PR DESCRIPTION
This pull request adds comprehensive right-to-left (RTL) layout support to the md-menu component.
The changes ensure correct alignment and improved usability for RTL languages.

Before:
<img width="280" height="155" alt="Old layout" src="https://github.com/user-attachments/assets/853bf871-1b0b-47e6-a141-5c6062c7b644" />

After:
<img width="269" height="152" alt="New layout" src="https://github.com/user-attachments/assets/1981f020-9a01-4b2a-93e9-f3fae5562aae" />

