### PR TITLE
Remove progress text color in SCSS

### DIFF
--- a/libs/ngx-ui-tour-md-menu/src/lib/tour-step-template/tour-default-step-template/tour-default-step-template.component.scss
+++ b/libs/ngx-ui-tour-md-menu/src/lib/tour-step-template/tour-default-step-template/tour-default-step-template.component.scss
@@ -19,6 +19,7 @@ mat-card-actions {
     .progress {
         font-size: 12px;
         font-weight: 600;
+        color: color-mix(in srgb, var(--mat-sys-on-surface, #1a1b1f) 45%, transparent);
         white-space: nowrap;
     }
 


### PR DESCRIPTION
Change progress text color to default.  If one is using a dark theme from Angular Material and using this Angular Material adjacent library, its plausible that a dark theme is in use, and this makes it very difficult to read.  One could create a whole custom theme to overcome this issue.  But this seems like the better solution because the color of the text should be dependent on choices outside the scope of this library, and if one wants to change the color of the text, they can create a custom template for that.